### PR TITLE
Update README.md to include info about GITHUB_TOKEN variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 AWS-SAM GitHub Actions allow you to run `sam build` and `sam deploy` and etc.
 
 ## Example usage
+### Build and deploy on push
 
 ```yaml
 on: [push]
@@ -32,6 +33,31 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ap-northeast-1
+```
+
+### Validate template on pull request
+```yaml
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  aws_sam_validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: sam validate
+        uses: youyo/aws-sam-action/python3.8@master
+        with:
+          sam_command: validate
+          actions_comment: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'ap-northeast-1'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Can I take a assume-role?
@@ -84,11 +110,13 @@ jobs:
 - `sam_command` **Required** AWS SAM subcommand to execute.
 - `sam_version` AWS SAM version to install. (default: 'latest')
 - `actions_comment` Whether or not to comment on pull requests. (default: false)
+  - If `true`, the `GITHUB_TOKEN` environment variable should be defined.
 
 ## ENV
 
 - `AWS_ACCESS_KEY_ID` **Required**
 - `AWS_SECRET_ACCESS_KEY` **Required**
+- `GITHUB_TOKEN`
 
 Recommended to get `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from secrets.
 


### PR DESCRIPTION
If `actions_comment` is set as true, an error is received if GITHUB_TOKEN is not defined. The README.md has been updated to include information about this requirement and also provide an example.