### PR TITLE
Adding 'make' to allow custom build files to run with aws sam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 
-RUN apk --update --no-cache add jq curl bash gcc musl-dev
+RUN apk --update --no-cache add jq curl bash gcc musl-dev build-base
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'AWS SAM GitHub Actions'
+name: 'AWS SAM GitHub Action - Draft'
 description: 'Runs AWS-SAM via GitHub Actions.'
 author: 'youyo <1003ni2@gmail.com>'
 branding:


### PR DESCRIPTION
This will allow custom Makefiles, e.g.

```yaml
  ...
  LambdaLayer:
    Type: AWS::Serverless::LayerVersion 
    Properties:
      LayerName: myLayerName
      CompatibleRuntimes: 
        - python3.8
        - python3.7
      RetentionPolicy: Retain
      ContentUri: pathToCodu
      Description: Some Layer
    Metadata:
      BuildMethod: makefile
```