### PR TITLE
feat: add installation of libffi-dev

### DIFF
--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 
-RUN apk --update --no-cache add jq curl bash gcc musl-dev build-base
+RUN apk --update --no-cache add jq curl bash gcc musl-dev build-base libffi-dev
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8-alpine
 
 ENV SAM_CLI_TELEMETRY 0
 
-RUN apk --update --no-cache add jq curl bash gcc musl-dev build-base
+RUN apk --update --no-cache add jq curl bash gcc musl-dev build-base libffi-dev
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Recently, python3.7 and python3.8 of this action are failing during installing latest aws-sam-cli.

After looking at the output of `pip install aws-sam-cli` of this action, I found out that it was caused by the lack of libeff-dev, so I added the installation of libeff-dev to Dockerfile of python3.7 and python3.8.